### PR TITLE
Chapter5 - Higher Order Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This project uses rules_python to properly setup dependencies like pytest and ot
 
 # Organization
 The code is organized as follows:
-    1. WORKSPACE and top level BUILD files - designate the project related items.
-    2. chapters module - This is the core of the project, where any new chapter module will be added. Each chapter contains certain aspects of python, that have been explored.
-    3. dependencies - Any third party dependencies needed by the modules. Eg., the tests use pytest, so it is one of the dependencies.
-    4. .gitignore file describing the artifacts to be ignored from consideration to adding into the repository.
-    5. .gitattributes file describing the line ending settings for the files.
+1. WORKSPACE and top level BUILD files - designate the project related items.
+2. chapters module - This is the core of the project, where any new chapter module will be added. Each chapter contains certain aspects of python, that have been explored.
+3. dependencies - Any third party dependencies needed by the modules. Eg., the tests use pytest, so it is one of the dependencies.
+4. .gitignore file describing the artifacts to be ignored from consideration to adding into the repository.
+5. .gitattributes file describing the line ending settings for the files.
 
 # Specifying Third Party Dependencies
 The way to specify dependencies is:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The way to specify dependencies is:
 
 # Adding a new chapter module
 1. Make folder with appropriate name in chapters module, and add __init__.py
-2. Create a build file for the module, and add a py_library target, and as many py_test targets as needed.
-3. Finally, group all the py_test targets into a testsuite, so that they can be referenced from the chapters module.
-4. In the chapters' BUILD file, add the module dependency to py_library, and add the testsuite target in the tests attribute of the global test suite.
-5. Then do bazel build functional_python, bazel test test_functional_python and verify that the newly added module is building and it's tests are executing.
+2. Create a build file for the module, and add a py_library target, and as many py_test targets as needed in the _TESTS list.
+3. In the chapters' BUILD file, add the module dependency to py_library, and add the testsuite target in the tests attribute of the global test suite.
+4. Then do bazel build functional_python, bazel test test_functional_python and verify that the newly added module is building and it's tests are executing.

--- a/chapters/BUILD
+++ b/chapters/BUILD
@@ -8,7 +8,9 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//chapters/functions_iterators_generators:func_iter_gen",
+        "//chapters/higher_order_functions",
         "//chapters/working_with_collections",
+
     ]
 )
 
@@ -16,6 +18,7 @@ test_suite(
     name = "test_functional_python",
     tests = [
         "//chapters/functions_iterators_generators:test_functions_iterators_generators",
-        "//chapters/working_with_collections:test_working_with_collections"
+        "//chapters/higher_order_functions:test_higher_order_functions",
+        "//chapters/working_with_collections:test_working_with_collections",
     ]
 )

--- a/chapters/BUILD
+++ b/chapters/BUILD
@@ -5,12 +5,12 @@ py_library(
     srcs = [
         "__init__.py",
     ],
+    imports = ["."],
     srcs_version = "PY3",
     deps = [
-        "//chapters/functions_iterators_generators:func_iter_gen",
+        "//chapters/functions_iterators_generators:functions_iterators_generators",
         "//chapters/higher_order_functions",
         "//chapters/working_with_collections",
-
     ]
 )
 

--- a/chapters/BUILD
+++ b/chapters/BUILD
@@ -8,7 +8,7 @@ py_library(
     imports = ["."],
     srcs_version = "PY3",
     deps = [
-        "//chapters/functions_iterators_generators:functions_iterators_generators",
+        "//chapters/functions_iterators_generators",
         "//chapters/higher_order_functions",
         "//chapters/working_with_collections",
     ]

--- a/chapters/functions_iterators_generators/BUILD
+++ b/chapters/functions_iterators_generators/BUILD
@@ -2,26 +2,32 @@ load("@dependencies_pytest//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//chapters:__pkg__"])
 
+IMPORTS = ["."]
+
 py_library(
-    name = "func_iter_gen",
+    name = "functions_iterators_generators",
     srcs = [
         "__init__.py",
         "power.py",
         "prime_factors.py",
         "static_mapping.py",
     ],
+    imports=IMPORTS,
     srcs_version = "PY3",
 )
+
+DEPS = [
+    ":functions_iterators_generators",
+    requirement("pytest")
+]
 
 py_test(
     name = "test_power",
     srcs = [
         "tests/test_power.py",
     ],
-    deps = [
-        ":func_iter_gen",
-        requirement("pytest")
-    ],
+    imports = IMPORTS,
+    deps = DEPS,
     visibility = ["//visibility:private"]
 )
 
@@ -31,10 +37,8 @@ py_test(
     srcs = [
         "tests/test_prime_factors.py"
     ],
-    deps = [
-        ":func_iter_gen",
-        requirement("pytest")
-    ],
+    imports = IMPORTS,
+    deps = DEPS,
     visibility = ["//visibility:private"]
 )
 
@@ -43,10 +47,8 @@ py_test(
     srcs = [
         "tests/test_static_mapping.py"
     ],
-    deps = [
-        ":func_iter_gen",
-        requirement("pytest")
-    ],
+    imports = IMPORTS,
+    deps = DEPS,
     visibility = ["//visibility:private"]
 )
 

--- a/chapters/functions_iterators_generators/BUILD
+++ b/chapters/functions_iterators_generators/BUILD
@@ -2,61 +2,41 @@ load("@dependencies_pytest//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//chapters:__pkg__"])
 
-IMPORTS = ["."]
+_MODULE = "functions_iterators_generators"
 
 py_library(
-    name = "functions_iterators_generators",
+    name = _MODULE,
     srcs = [
         "__init__.py",
         "power.py",
         "prime_factors.py",
         "static_mapping.py",
     ],
-    imports=IMPORTS,
+    imports=["."],
     srcs_version = "PY3",
 )
 
-DEPS = [
-    ":functions_iterators_generators",
-    requirement("pytest")
+_TESTS = [
+    "test_power",
+    "test_prime_factors",
+    "test_static_mapping"
 ]
 
+[
 py_test(
-    name = "test_power",
+    name = "%s" %(n),
     srcs = [
-        "tests/test_power.py",
+        "tests/%s.py" %(n),
     ],
-    imports = IMPORTS,
-    deps = DEPS,
-    visibility = ["//visibility:private"]
-)
-
-
-py_test(
-    name = "test_prime_factors",
-    srcs = [
-        "tests/test_prime_factors.py"
+    imports = ["."],
+    deps = [
+        ":%s"%(_MODULE),
+        requirement("pytest")
     ],
-    imports = IMPORTS,
-    deps = DEPS,
     visibility = ["//visibility:private"]
-)
-
-py_test(
-    name = "test_static_mapping",
-    srcs = [
-        "tests/test_static_mapping.py"
-    ],
-    imports = IMPORTS,
-    deps = DEPS,
-    visibility = ["//visibility:private"]
-)
+) for n in _TESTS
+]
 
 test_suite(
-    name = "test_functions_iterators_generators",
-    tests = [
-        ":test_power",
-        ":test_prime_factors",
-        ":test_static_mapping"
-    ],
+    name = "test_%s" %(_MODULE),
 )

--- a/chapters/functions_iterators_generators/tests/test_power.py
+++ b/chapters/functions_iterators_generators/tests/test_power.py
@@ -1,5 +1,5 @@
 import pytest
-from chapters.functions_iterators_generators import power
+import power
 
 def test_power_shifty():
     assert power.shift(4) == 15
@@ -17,4 +17,4 @@ def test_power_faster():
 
 
 if __name__=="__main__":
-    raise SystemExit(pytest.main([__file__]))
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/chapters/functions_iterators_generators/tests/test_prime_factors.py
+++ b/chapters/functions_iterators_generators/tests/test_prime_factors.py
@@ -1,5 +1,5 @@
 import pytest
-from chapters.functions_iterators_generators import prime_factors as pf
+import prime_factors as pf
 from typing import List
 
 TEST_VALUES = {

--- a/chapters/functions_iterators_generators/tests/test_static_mapping.py
+++ b/chapters/functions_iterators_generators/tests/test_static_mapping.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from chapters.functions_iterators_generators import static_mapping
+import static_mapping
 import pytest
 
 Color = namedtuple("Color", ("red", "green", "blue", "name"))

--- a/chapters/higher_order_functions/BUILD
+++ b/chapters/higher_order_functions/BUILD
@@ -5,14 +5,16 @@ package(default_visibility = ["//chapters:__pkg__"])
 _MODULE = "higher_order_functions"
 
 _TESTS = [
-    "test_min_max"
+    "test_min_max",
+    "test_map_filter"
 ]
 
 
 py_library(
     name = _MODULE,
     srcs = [
-        "min_max.py"
+        "map_filter.py",
+        "min_max.py",
     ],
     imports = ["."],
     srcs_version = "PY3",

--- a/chapters/higher_order_functions/BUILD
+++ b/chapters/higher_order_functions/BUILD
@@ -1,0 +1,18 @@
+load ("@dependencies_pytest//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//chapters:__pkg__"])
+
+py_library(
+    name = "higher_order_functions",
+    srcs = [
+
+    ],
+    srcs_version = "PY3"
+)
+
+test_suite(
+    name = "test_higher_order_functions",
+    tests = [
+
+    ]
+)

--- a/chapters/higher_order_functions/BUILD
+++ b/chapters/higher_order_functions/BUILD
@@ -2,17 +2,42 @@ load ("@dependencies_pytest//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//chapters:__pkg__"])
 
-py_library(
-    name = "higher_order_functions",
-    srcs = [
+_MODULE = "higher_order_functions"
 
+_TESTS = [
+    "test_min_max"
+]
+
+
+py_library(
+    name = _MODULE,
+    srcs = [
+        "min_max.py"
     ],
-    srcs_version = "PY3"
+    imports = ["."],
+    srcs_version = "PY3",
+    deps = [
+        "//chapters/working_with_collections",
+    ]
 )
 
-test_suite(
-    name = "test_higher_order_functions",
-    tests = [
 
-    ]
+[
+    py_test(
+        name = "%s" %(n),
+        srcs = [
+            "tests/%s.py" %(n),
+        ],
+        imports = ["."],
+        deps = [
+            ":%s" %(_MODULE),
+            requirement("pytest")
+        ]
+    )
+    for n in _TESTS
+]
+
+
+test_suite(
+    name = "test_%s"%(_MODULE),
 )

--- a/chapters/higher_order_functions/BUILD
+++ b/chapters/higher_order_functions/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//chapters:__pkg__"])
 _MODULE = "higher_order_functions"
 
 _TESTS = [
+    "test_callable_classes",
     "test_min_max",
     "test_map_filter"
 ]
@@ -13,6 +14,7 @@ _TESTS = [
 py_library(
     name = _MODULE,
     srcs = [
+        "callable_classes.py",
         "map_filter.py",
         "min_max.py",
     ],

--- a/chapters/higher_order_functions/BUILD
+++ b/chapters/higher_order_functions/BUILD
@@ -18,6 +18,9 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//chapters/working_with_collections",
+    ],
+    data = [
+        "//chapters/working_with_collections/data:kml_files"
     ]
 )
 

--- a/chapters/higher_order_functions/callable_classes.py
+++ b/chapters/higher_order_functions/callable_classes.py
@@ -1,0 +1,51 @@
+from typing import Callable, Optional, Any, Iterable
+
+"""
+This module presents a couple of examples, defining higher-order functions as
+callable classes. This builds on the idea of writing generator functions.
+This allows us to use statement features of Python, and also apply static
+configuration when creating the higher-order functions.
+"""
+
+class NullAware:
+    """
+    This class is used to create a new function that is nullaware. When an
+    instance of this class is created, a function, some_func is provided. The
+    only restriction is that some_func be Callable[[Any], Any]. This means the
+    argument takes a single argument and results in a single result.
+    The implementation of the __call__() method handles the use of None objects
+    as an argument. This method has the effect of making the resulting object
+    Callable[[Optional[Any]], Optional[Any]]
+    """
+    def __init__(self, some_func: Callable[[Any], Any]) -> None:
+        self.some_func = some_func
+
+    def __call__(self, arg: Optional[Any]) -> Optional[Any]:
+        return None if arg is None else self.some_func(arg)
+
+
+class Map_Filter:
+    """
+    This class has precisely two slots in each object; this puts a few constraints
+    on our ability to use the function as a stateful object. It doesn't prevent all
+    modifications to the resulting object, but it limits us to jsut two attributes.
+    Attempting to add attributes results in an exception.
+    The initialization method, __init__(), stows the two function names, filter and
+    func, in the object's instance variables. The __call__() method returns a value
+    based on a generator expression that uses the two internal function definitions.
+    The self.filter() is used to pass or reject items. The self.function() is used
+    to transform objects that are passed by the filter() function.
+    """
+    __slots__ = ["filter", "function"]
+    def __init__(self, filt: Callable[[Any], bool], func: Callable[[Any], float]) -> None:
+        self.filter = filt
+        self.function = func
+
+    def __call__(self, iterable: Iterable) -> float:
+        return sum(self.function(x) for x in iterable if self.filter(x))
+
+
+count_not_none = Map_Filter(
+    lambda x : x is not None,
+    lambda _ : 1
+)

--- a/chapters/higher_order_functions/map_filter.py
+++ b/chapters/higher_order_functions/map_filter.py
@@ -1,0 +1,89 @@
+
+"""
+This module explores various ways of applying map and filter functions
+to sequences, iterables
+"""
+from typing import Callable, Any, Iterable, TypeVar, Tuple, Iterator
+from chapters.working_with_collections.sequence_structure import group_by_iter
+from math import sqrt as msqrt
+
+T_ = TypeVar("T_")
+
+def star_map(function: Callable[[Any], T_], *iterables: Iterable[Any]) -> Iterable[T_]:
+    """
+    A general map function, that takes n arguments of different types, and returns a single
+    type as a result. This function returns an iterable, so that the memory consumption is
+    preserved.wg
+    """
+    return (function(*args) for args in zip(*iterables))
+
+
+def star_filter(function: Callable[[Any], bool], *iterables: Iterable[Any]) -> Iterable[Tuple[Any]]:
+    """
+    A general filter function, that takes n argument iterator, a predicate that returns true/false,
+    and then only returns those iterable for which the predicate returned true.
+    The return value is not exactly what we want, since we need to figure out a way to unzip the
+    iterables so that a tuple of iterables is not returned.
+    """
+    return (args for args in zip(*iterables) if function(*args))
+
+
+Point = Tuple[float, float]
+Leg_Raw = Tuple[Point, Point]
+Point_Func = Callable[[Point, Point], float]
+Leg_P_D = Tuple[Leg_Raw, ...]
+
+
+def cons_distance( distance: Point_Func, legs_iter: Iterable[Leg_Raw]) -> Iterator[Leg_P_D]:
+    return (
+        leg + (round(distance(*leg), 4),)   # 1-tuple
+        for leg in legs_iter
+    )
+
+
+def group_filter_iter( n: int, pred: Callable[[Any], bool], items: Iterator) -> Iterator:
+    subset = filter(pred, items)
+    return group_by_iter(n, iter(subset))
+
+
+def first(predicate: Callable[[Any], bool], collection: Iterable) -> Any:
+    """
+    This function applies a predicate to each value in the collection until it returns
+    false. The moment the predicate returns true, the corresponding value will be returned
+    without further processing the collection.
+    """
+    for x in collection:
+        if predicate(x):
+            return x
+
+    return None
+
+
+def isprimeh(x: int) -> bool:
+    """
+    This is a simple primality testing function, which demonstrates an application of
+    the first function.
+    """
+    if x == 2: return True
+    if x % 2 == 0: return False
+    factor = first (
+        lambda n: x % n == 0,
+        range(3, int(msqrt(x) + .5)  + 1, 2))
+
+    return factor is None
+
+
+def map_not_none(func: Callable, source: Iterable) -> Iterator:
+    """
+    This function steps through the items in the iterable, assigning each item to the
+    x variable. It attempts to apply the function to the item; if no exception is
+    raised, the resulting value is yielded. If an exception is raised, the offending
+    source item is silently dropped. Ofcourse, the exception details are print.
+    This can be handy when dealing with data that include values that are not applicable
+    or missing.
+    """
+    for x in source:
+        try:
+            yield func(x)
+        except Exception as e:
+            print(e)

--- a/chapters/higher_order_functions/min_max.py
+++ b/chapters/higher_order_functions/min_max.py
@@ -1,0 +1,36 @@
+from typing import Iterator, Iterable, Tuple, Any, TextIO, Callable
+from  chapters.working_with_collections import kml_parser as kp
+
+"""
+This module explores some ways to use the min and max functions,
+and also defines custom max_like and min_like functions that take
+a callable to do custom processing.
+"""
+Wrapped = Tuple[Any, Tuple]
+
+
+def wrap(leg_iter: Iterable[Tuple]) -> Iterable[Wrapped]:
+    return ((leg[2], leg) for leg in leg_iter)
+
+
+def unwrap(dist_leg: Tuple[Any, Any]) -> Any:
+    _, leg = dist_leg
+    return leg
+
+
+def max_like(source: TextIO, key: Callable = lambda x : x) -> Any:
+    wrp = ((key(leg), leg) for leg in kp.trip(source))
+    return sorted(wrp)[-1][1]
+
+
+def min_like(source: TextIO, key: Callable = lambda x : x) -> Any:
+    wrp = ((key(leg), leg) for leg in kp.trip(source))
+    return sorted(wrp, reverse=True)[-1][1]
+
+
+def long(source: TextIO) -> kp.LL_Float:
+    return unwrap(max(wrap(kp.trip(source))))
+
+
+def short(source: TextIO) -> kp.LL_Float:
+    return unwrap(min(wrap(kp.trip(source))))

--- a/chapters/higher_order_functions/tests/test_callable_classes.py
+++ b/chapters/higher_order_functions/tests/test_callable_classes.py
@@ -1,0 +1,26 @@
+import pytest
+import callable_classes as cc
+from math import log as mlog
+from typing import List
+
+def compare_numeric_lists(list1: List[float], list2: List[float]) -> bool:
+    eps = 0.0001
+    for (v1, v2) in zip(list1, list2):
+        if pytest.approx(v1, eps) != pytest.approx(v2, eps):
+            return False
+    return True
+
+
+def test_nullaware() -> None:
+    null_log_scale = cc.NullAware(mlog)
+    scaled = map(null_log_scale, [10, 100, None, 50, 60])
+    print(list(scaled))
+    assert(compare_numeric_lists(list(scaled), [2.3025850929, 4.605170185988, None, 3.912023005428, 4.094344562]))
+
+
+def test_count_not_none() -> None:
+    assert(cc.count_not_none([1, 2, 3, None, 5, 6, None]) == 5)
+
+
+if __name__=="__main__":
+    SystemExit(pytest.main([__file__, "-v", "-s"]))

--- a/chapters/higher_order_functions/tests/test_map_filter.py
+++ b/chapters/higher_order_functions/tests/test_map_filter.py
@@ -1,5 +1,43 @@
 import pytest
-import map_filter
+import map_filter as mf
+
+def test_star_map() -> None:
+    LIST = [1,2,3,4]
+    assert(list(mf.star_map(lambda x : x**2, LIST)) == [1,4,9,16])
+
+
+def test_star_filter() -> None:
+    LIST = [1,2,3,4,5,6,7,8,9,10]
+    assert(list(mf.star_filter(lambda x : x % 2 == 0, LIST)) == [(2,),(4,),(6,),(8,),(10,)])
+
+
+def test_group_filter_iter() -> None:
+    assert(list(mf.group_filter_iter(
+        7,
+        lambda x: x % 3 == 0 or x % 5 == 0,
+        range(1,100)
+    )) ==
+    [(3, 5, 6, 9, 10, 12, 15),
+     (18, 20, 21, 24, 25, 27, 30),
+     (33, 35, 36, 39, 40, 42, 45),
+     (48, 50, 51, 54, 55, 57, 60),
+     (63, 65, 66, 69, 70, 72, 75),
+     (78, 80, 81, 84, 85, 87, 90),
+     (93, 95, 96, 99)])
+
+
+def test_first() -> None:
+    assert(mf.first(lambda x: x % 2 == 0, [1,3,5,7,8]) == 8)
+
+
+def test_isprimeh() -> None:
+    assert(mf.isprimeh(17) == True)
+
+
+def test_map_not_none() -> None:
+    assert(list(mf.map_not_none(
+        int, ["1", "2", "abc", "3", "def", "4"]
+    )) == [1,2,3,4])
 
 
 if __name__=="__main__":

--- a/chapters/higher_order_functions/tests/test_map_filter.py
+++ b/chapters/higher_order_functions/tests/test_map_filter.py
@@ -1,0 +1,6 @@
+import pytest
+import map_filter
+
+
+if __name__=="__main__":
+    SystemExit(pytest.main([__file__, "-v", "-s"]))

--- a/chapters/higher_order_functions/tests/test_min_max.py
+++ b/chapters/higher_order_functions/tests/test_min_max.py
@@ -1,0 +1,29 @@
+import min_max
+import pytest
+
+def test_long():
+    with open("chapters/working_with_collections/data/KML_Sample.kml", "r") as f:
+        print(min_max.long(f))
+    assert(True)
+
+
+def test_short():
+    with open("chapters/working_with_collections/data/KML_Sample.kml", "r") as f:
+        print(min_max.short(f))
+    assert(True)
+
+
+def test_max_like():
+    with open("chapters/working_with_collections/data/KML_Sample.kml", "r") as f:
+        print(min_max.max_like(f))
+    assert(True)
+
+
+def test_min_like():
+    with open("chapters/working_with_collections/data/KML_Sample.kml", "r") as f:
+        print(min_max.min_like(f))
+    assert(True)
+
+
+if __name__=="__main__":
+    SystemExit(pytest.main([__file__, "-v", "-s"]))

--- a/chapters/working_with_collections/BUILD
+++ b/chapters/working_with_collections/BUILD
@@ -1,11 +1,11 @@
 load ("@dependencies_pytest//:requirements.bzl", "requirement")
 
-package(default_visibility = ["//chapters:__pkg__"])
+package(default_visibility = ["//chapters:__subpackages__"])
 
-_IMPORTS = ["."]
+_MODULE = "working_with_collections"
 
 py_library(
-    name="working_with_collections",
+    name=_MODULE,
     srcs = [
         "adjacent_pairer.py",
         "basic_stats.py",
@@ -14,74 +14,39 @@ py_library(
         "kml_parser.py",
         "sequence_structure.py"
     ],
-    imports = _IMPORTS,
+    imports = ["."],
     srcs_version = "PY3",
 )
 
-_DEPS =  [
-        ":working_with_collections",
-        requirement("pytest")
-    ]
 
 _TESTS = [
-    ":test_adjacent_pairer",
-    ":test_basic_stats",
-    ":test_kml_parser",
-    ":test_sequence_structure"
+    "test_adjacent_pairer",
+    "test_basic_stats",
+    "test_kml_parser",
+    "test_sequence_structure"
 ]
 
+
+[
 py_test(
-    name = "test_kml_parser",
+    name = "%s" %(n),
     srcs = [
-        "tests/test_kml_parser.py"
+        "tests/%s.py" %(n)
     ],
-    imports = _IMPORTS,
-    deps = _DEPS,
+    imports = ["."],
+    deps = [
+        ":%s"%(_MODULE),
+        requirement("pytest")
+    ],
     data = [
         "//chapters/working_with_collections/data:kml_files",
     ],
     visibility = ["//visibility:private"]
 )
+for n in _TESTS
+]
 
-py_test(
-    name = "test_adjacent_pairer",
-    srcs = [
-        "tests/test_adjacent_pairer.py"
-    ],
-    imports = _IMPORTS,
-    deps =_DEPS,
-    data = [
-        "//chapters/working_with_collections/data:kml_files",
-    ],
-    visibility = ["//visibility:private"]
-)
-
-py_test(
-    name = "test_basic_stats",
-    srcs = [
-        "tests/test_basic_stats.py"
-    ],
-    imports = _IMPORTS,
-    deps = _DEPS,
-    visibility = ["//visibility:private"]
-)
-
-py_test(
-    name = "test_sequence_structure",
-    srcs = [
-        "tests/test_sequence_structure.py"
-    ],
-    imports = _IMPORTS,
-    deps = _DEPS,
-    visibility = ["//visibility:private"]
-)
 
 test_suite(
-    name="test_working_with_collections",
-    tests = [
-        ":test_adjacent_pairer",
-        ":test_basic_stats",
-        ":test_kml_parser",
-        ":test_sequence_structure"
-    ]
+    name="test_%s"%(_MODULE),
 )

--- a/chapters/working_with_collections/BUILD
+++ b/chapters/working_with_collections/BUILD
@@ -2,6 +2,8 @@ load ("@dependencies_pytest//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//chapters:__pkg__"])
 
+_IMPORTS = ["."]
+
 py_library(
     name="working_with_collections",
     srcs = [
@@ -12,18 +14,29 @@ py_library(
         "kml_parser.py",
         "sequence_structure.py"
     ],
+    imports = _IMPORTS,
     srcs_version = "PY3",
 )
+
+_DEPS =  [
+        ":working_with_collections",
+        requirement("pytest")
+    ]
+
+_TESTS = [
+    ":test_adjacent_pairer",
+    ":test_basic_stats",
+    ":test_kml_parser",
+    ":test_sequence_structure"
+]
 
 py_test(
     name = "test_kml_parser",
     srcs = [
         "tests/test_kml_parser.py"
     ],
-    deps = [
-        ":working_with_collections",
-        requirement("pytest")
-    ],
+    imports = _IMPORTS,
+    deps = _DEPS,
     data = [
         "//chapters/working_with_collections/data:kml_files",
     ],
@@ -35,10 +48,8 @@ py_test(
     srcs = [
         "tests/test_adjacent_pairer.py"
     ],
-    deps = [
-        ":working_with_collections",
-        requirement("pytest")
-    ],
+    imports = _IMPORTS,
+    deps =_DEPS,
     data = [
         "//chapters/working_with_collections/data:kml_files",
     ],
@@ -50,10 +61,8 @@ py_test(
     srcs = [
         "tests/test_basic_stats.py"
     ],
-    deps = [
-        ":working_with_collections",
-        requirement("pytest")
-    ],
+    imports = _IMPORTS,
+    deps = _DEPS,
     visibility = ["//visibility:private"]
 )
 
@@ -62,10 +71,8 @@ py_test(
     srcs = [
         "tests/test_sequence_structure.py"
     ],
-    deps = [
-        ":working_with_collections",
-        requirement("pytest")
-    ],
+    imports = _IMPORTS,
+    deps = _DEPS,
     visibility = ["//visibility:private"]
 )
 

--- a/chapters/working_with_collections/data/BUILD
+++ b/chapters/working_with_collections/data/BUILD
@@ -3,5 +3,8 @@ filegroup(
     srcs = [
         "KML_Sample.kml"
     ],
-    visibility = ["//chapters/working_with_collections:__pkg__"]
+    visibility = [
+        "//chapters/working_with_collections:__pkg__",
+        "//chapters/higher_order_functions:__pkg__",
+    ]
 )

--- a/chapters/working_with_collections/kml_parser.py
+++ b/chapters/working_with_collections/kml_parser.py
@@ -42,7 +42,8 @@ def pick_lat_lon(lon: Text, lat: Text, alt: Text) -> Tuple[Text, Text]:
 Rows = Iterable[List[Text]]
 LL_Text = Tuple[Text,Text]
 LL_Text_Iter = Iterable[LL_Text]
-LL_Float_Iter = Iterable[Tuple[float, float]]
+LL_Float = Tuple[float, float]
+LL_Float_Iter = Iterable[LL_Float]
 
 
 def lat_lon_kml(row_iter: Rows) -> LL_Text_Iter:

--- a/chapters/working_with_collections/kml_parser.py
+++ b/chapters/working_with_collections/kml_parser.py
@@ -18,7 +18,7 @@ objects out of the text and attribute values.
 
 import xml.etree.ElementTree as XML
 from typing import Text, List, TextIO, Iterable, Tuple
-from chapters.working_with_collections import haversine
+import haversine
 
 def row_iter_kml(file_obj: TextIO) -> Iterable[List[Text]]:
     ns_map = {

--- a/chapters/working_with_collections/tests/test_adjacent_pairer.py
+++ b/chapters/working_with_collections/tests/test_adjacent_pairer.py
@@ -1,4 +1,4 @@
-from chapters.working_with_collections import adjacent_pairer as ap
+import adjacent_pairer as ap
 import pytest
 
 def test_pairs_recursive() -> None:

--- a/chapters/working_with_collections/tests/test_basic_stats.py
+++ b/chapters/working_with_collections/tests/test_basic_stats.py
@@ -1,4 +1,4 @@
-from chapters.working_with_collections import basic_stats as bs
+import basic_stats as bs
 import pytest
 
 

--- a/chapters/working_with_collections/tests/test_kml_parser.py
+++ b/chapters/working_with_collections/tests/test_kml_parser.py
@@ -1,4 +1,4 @@
-from chapters.working_with_collections import kml_parser
+import kml_parser
 import pytest
 #According to the following stack overflow post, import urllib.request rather than just urllib.
 # https://stackoverflow.com/questions/37042152/python-3-5-1-urllib-has-no-attribute-request
@@ -7,7 +7,7 @@ import urllib.request
 URL = "https://developers.google.com/kml/documentation/KML_Samples.kml"
 
 def test_kml_parser() -> None:
-    with open("working_with_collections/data/KML_Sample.kml", "r") as source:
+    with open("chapters/working_with_collections/data/KML_Sample.kml", "r") as source:
         for  row in kml_parser.row_iter_kml(source):
             print (row)
 

--- a/chapters/working_with_collections/tests/test_sequence_structure.py
+++ b/chapters/working_with_collections/tests/test_sequence_structure.py
@@ -1,4 +1,4 @@
-from chapters.working_with_collections import sequence_structure as ss
+import sequence_structure as ss
 import pytest
 
 LIST1 = [1,2,3,4,5,6]


### PR DESCRIPTION
1. Reduce duplication in Bazel build files.
2. Create modules that explore various aspects of creating and consuming higher-order-functions.
3. callable_classes module explores how to declare callable classes, and introduce a new behavior to existing functions.
4. min_max module explores the max_like and min_like functions that accept callable parameters that do custom processing.
5. map_filter module explores some ways of creating the map and filter functions, that almost mimic the builtin functions.