### PR TITLE
Fixed the build for linux, but it will break on windows.

### DIFF
--- a/.ijwb/.bazelproject
+++ b/.ijwb/.bazelproject
@@ -1,0 +1,16 @@
+directories:
+  .
+
+# Automatically includes all relevant targets under the 'directories' above
+derive_targets_from_directories: true
+
+targets:
+  # If source code isn't resolving, add additional targets that compile it here
+
+additional_languages:
+  # Uncomment any additional languages you want supported
+  # android
+  # dart
+  # kotlin
+  python
+  # scala

--- a/.ijwb/.blaze/modules/.project-data-dir.iml
+++ b/.ijwb/.blaze/modules/.project-data-dir.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.system.id="Blaze" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../..">
+      <excludeFolder url="file://$MODULE_DIR$/.." />
+      <excludeFolder url="file://$MODULE_DIR$/../../.idea" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.ijwb/.blaze/modules/.workspace.iml
+++ b/.ijwb/.blaze/modules/.workspace.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.system.id="Blaze" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="Python" name="Python">
+      <configuration sdkName="Python 3.6" />
+    </facet>
+  </component>
+  <component name="NewModuleRootManager">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../../..">
+      <sourceFolder url="file://$MODULE_DIR$/../../.." isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/../.." />
+      <excludeFolder url="file://$MODULE_DIR$/../../../bazel-bin" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../bazel-functional_python" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../bazel-genfiles" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../bazel-out" />
+      <excludeFolder url="file://$MODULE_DIR$/../../../bazel-testlogs" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Python 3.6 interpreter library" level="application" />
+  </component>
+</module>

--- a/.ijwb/.idea/.gitignore
+++ b/.ijwb/.idea/.gitignore
@@ -1,0 +1,4 @@
+# Default ignored files
+/workspace.xml
+# Project exclude paths
+/.

--- a/.ijwb/.idea/.name
+++ b/.ijwb/.idea/.name
@@ -1,0 +1,1 @@
+functional_python

--- a/.ijwb/.idea/codeStyles/codeStyleConfig.xml
+++ b/.ijwb/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.ijwb/.idea/externalDependencies.xml
+++ b/.ijwb/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="com.google.idea.bazel.ijwb" />
+  </component>
+</project>

--- a/.ijwb/.idea/misc.xml
+++ b/.ijwb/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <type id="android" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+</project>

--- a/.ijwb/.idea/modules.xml
+++ b/.ijwb/.idea/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.blaze/modules/.project-data-dir.iml" filepath="$PROJECT_DIR$/.blaze/modules/.project-data-dir.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.blaze/modules/.workspace.iml" filepath="$PROJECT_DIR$/.blaze/modules/.workspace.iml" />
+    </modules>
+  </component>
+</project>

--- a/.ijwb/.idea/runConfigurations.xml
+++ b/.ijwb/.idea/runConfigurations.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.run.AndroidConfigurationProducer" />
+        <option value="com.android.tools.idea.testartifacts.instrumented.AndroidTestConfigurationProducer" />
+        <option value="com.android.tools.idea.testartifacts.junit.TestClassAndroidConfigurationProducer" />
+        <option value="com.android.tools.idea.testartifacts.junit.TestDirectoryAndroidConfigurationProducer" />
+        <option value="com.android.tools.idea.testartifacts.junit.TestMethodAndroidConfigurationProducer" />
+        <option value="com.android.tools.idea.testartifacts.junit.TestPackageAndroidConfigurationProducer" />
+        <option value="com.android.tools.idea.testartifacts.junit.TestPatternConfigurationProducer" />
+        <option value="com.intellij.execution.application.ApplicationConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestMethodConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="com.jetbrains.python.run.PythonRunConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.PyTestsConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.PythonTestLegacyConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.doctest.PythonDocTestConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.nosetestLegacy.PythonNoseTestConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.pytestLegacy.PyTestConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.tox.PyToxConfigurationProducer" />
+        <option value="com.jetbrains.python.testing.unittestLegacy.PythonUnitTestConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.run.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.run.KotlinPatternConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.run.KotlinRunConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.GradleGroovyScriptRunConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInDirectoryGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.PatternGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.service.execution.GradleRuntimeConfigurationProducer" />
+        <option value="org.jetbrains.plugins.scala.runner.ScalaApplicationConfigurationProducer" />
+        <option value="org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestConfigurationProducer" />
+        <option value="org.jetbrains.plugins.scala.testingSupport.test.specs2.Specs2ConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.ijwb/.idea/vcs.xml
+++ b/.ijwb/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/dependencies/pytest/BUILD
+++ b/dependencies/pytest/BUILD
@@ -1,7 +1,9 @@
+load("@dependencies_pytest//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_test(
-    name = "pytest_test",
+    name = "test_pytest",
     srcs = [
         "test_pytest.py",
     ],

--- a/dependencies/requirements.bzl
+++ b/dependencies/requirements.bzl
@@ -2,7 +2,9 @@ load("@rules_python//python:pip.bzl", "pip_import")
 
 
 #TODO: Write a rule in bazel to download the python interpreter and then run the code.
-interpreter_path = "C:/Program Files (x86)/Microsoft Visual Studio/Shared/Python37_64/python.exe"
+#interpreter_path = "C:/Program Files (x86)/Microsoft Visual Studio/Shared/Python37_64/python.exe"
+interpreter_path = "/usr/bin/python3.6"
+
 
 
 def load_deps():


### PR DESCRIPTION
The goal of this PR is to allow bazel to find the current platform on which it is running and, then appropriately select the python interpreter.